### PR TITLE
Make centos 7 work

### DIFF
--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /usr/src && \
     curl -o git-1.9.4.tar.gz https://www.kernel.org/pub/software/scm/git/git-1.9.4.tar.gz && \
     tar xzf git-1.9.4.tar.gz && cd git-1.9.4 && \
     make prefix=/usr all && make prefix=/usr install && \
-    cd .. && rm -r git-1.9.4.tar.gz git-1.9.4
+    cd .. && rm -rf git-1.9.4.tar.gz git-1.9.4
 
 RUN echo "export PATH=\${PATH}:/opt/rh/ruby193/root/usr/local/bin" | tee -a /opt/rh/ruby193/enable
 RUN source /opt/rh/ruby193/enable

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Jesse Reynolds @jessereynolds
 #RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN rpm -ivh http://download.fedoraproject.org/pub/epel/7/$(arch)/e/epel-release-7-5.noarch.rpm
-#RUN yum install -y centos-release-SCL
 RUN yum groupinstall -y 'Development Tools'
 
 RUN yum install -y \
@@ -14,11 +13,13 @@ RUN yum install -y \
     perl-ExtUtils-MakeMaker \
     curl-devel \
     golang \
-    ruby193 \
-    ruby193-ruby-devel \
     tar \
     fakeroot \
-    cmake
+    cmake \
+    ruby \
+    ruby-devel
+
+RUN gem install bundler
 
 # Work around git/go version issues on centos - https://twitter.com/gniemeyer/status/472318780472045568
 RUN yum remove -y git
@@ -27,15 +28,9 @@ RUN cd /usr/src && \
     curl -o git-1.9.4.tar.gz https://www.kernel.org/pub/software/scm/git/git-1.9.4.tar.gz && \
     tar xzf git-1.9.4.tar.gz && cd git-1.9.4 && \
     make prefix=/usr all && make prefix=/usr install && \
-    cd .. && rm -r git-1.9.4.tar.gz git-1.9.4
-
-RUN echo "export PATH=\${PATH}:/opt/rh/ruby193/root/usr/local/bin" | tee -a /opt/rh/ruby193/enable
-RUN source /opt/rh/ruby193/enable
-
-RUN cp /opt/rh/ruby193/enable /etc/profile.d/ruby193.sh
+    cd .. && rm -rf git-1.9.4.tar.gz git-1.9.4
 
 RUN git config --global user.email "docker@flapjack.io" && \
     git config --global user.name "Flapjack Docker Packager"
 
 RUN /bin/bash -l -c "git clone https://github.com/flapjack/omnibus-flapjack.git && cd omnibus-flapjack && bundle install --binstubs"
-


### PR DESCRIPTION
Ruby 1.9 was in the SCL, which is, and will always be, unavailable for Centos 7.  Ruby 2.0 is in the repositories, which this has been updated to use.

If we do want go for 1.9, we'll need to either compile from source, or use rvm/rbenv/chruby.

@jessereynolds @ali-graham, what are your thoughts here?
